### PR TITLE
Add metadata-based robots and sitemap

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from "next";
 
+const host = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
 const nextConfig: NextConfig = {
   poweredByHeader: false,
-  pageExtensions: ["ts", "tsx", "md", "mdx"]
+  pageExtensions: ["ts", "tsx", "md", "mdx"],
+  metadataBase: new URL(host),
 };
 
 export default nextConfig;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/private/',
+    },
+    sitemap: '/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: '/',
+      lastModified: new Date(),
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- replace route handlers with metadata-based robots and sitemap
- configure `metadataBase` using `NEXT_PUBLIC_SITE_URL`

## Testing
- `npm install`
- `npm run build` *(fails fetching Rubik font)*

------
https://chatgpt.com/codex/tasks/task_e_687ad3943d28832f95c71f3a16964a0e